### PR TITLE
Add module function for bash

### DIFF
--- a/R/moduleInit.R
+++ b/R/moduleInit.R
@@ -40,7 +40,7 @@ moduleInit <- function( version = '3.2.10',
     Sys.setenv( LOADEDMODULES = "" )
   }
   # for {r, engine="bash"} in Rmarkdown/other bash subprocesses to use 'module' function
-  if( shell_is_bash() ) {
+  if( shell_has_bash() ) {
     module_function <- bash_func_name()
     if( is.na(Sys.getenv(module_function, unset = NA)) ) {
       env_var <- list(f = paste("() {  eval `", file.path(modulesHome, "bin/modulecmd"), " bash ${1+\"$@\"}`; }",
@@ -51,13 +51,20 @@ moduleInit <- function( version = '3.2.10',
   }
 }
 
-shell_is_bash <- function() {
-  basename(Sys.getenv("SHELL")) == "bash"
+shell_has_bash <- function() {
+  ## $SHELL is login shell bash - set by all shells
+  ## $0 is process name
+  ## $BASH is set by bash even when sh is symlinked to bash (/bin/sh rather than /bin/bash)
+  bash <-
+    system("{ which bash >/dev/null && bash -c 'basename ${SHELL:-unset}; basename $0; basename ${BASH:-unset}'; } || echo unset",
+           intern = TRUE)
+  any(bash == "bash") & any(bash == "unset") == FALSE
 }
 
 # probe the system to discover naming scheme BASH_FUNC_module%% vs BASH_FUNC_module()
 bash_func_name <- function() {
-  name_scheme <- system("__r() { : ;}; export -f __r; env | grep ^BASH_FUNC___r",
+  ## system() uses sh which is often not linked/copy of bash, but another shell e.g. dash
+  name_scheme <- system("bash -c '__r() { : ;}; export -f __r; env | grep ^BASH_FUNC___r'",
                         intern = TRUE)
   name_scheme <- gsub(pattern = "(BASH_FUNC___r|=.*)", replacement = "", x = name_scheme)
   func_name   <- paste("BASH_FUNC_module", name_scheme, sep = "")


### PR DESCRIPTION
## Aim

Resolve a usability issue in rmarkdown documents that use

    ```{r, engine="bash"}
    module load samtools
    samtools view experiment.bam
    ```

While this is quite easily resolved using `RLinuxModules::module("load samtools")` in R, or by including `source $MODULESHOME/init/bash` in each shell, this may be a more scoped and do what I mean solution.